### PR TITLE
Add OSGI compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,31 @@
                     </checkModificationExcludes>
                 </configuration>
             </plugin>
-            <!-- MAVEN RELEASE -->
+	    <!-- MAVEN RELEASE -->
+
+	    <!-- OSGI compatibility -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <!-- OSGI compatibility -->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,8 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <executions>
+                <extensions>true</extensions>    
+		<executions>
                     <execution>
                         <phase>process-classes</phase>
                         <goals>


### PR DESCRIPTION
The current version is not compatible with OSGI since the MANIFEST.MF is not generated, causing OSGI projects using this library to crash at runtime.

This is fixed by adding 2 plugins allowing the MANIFEST.MF to be generated

